### PR TITLE
Починил ошибки логирования на версиях zigbee2mqtt 1.21 и новее

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-zigbee2mqtt (1.2.0) stable; urgency=medium
+
+  * fix logging in zigbee2mqtt 1.21.x and above
+
+ -- Alexander Degtyarev <a.degtyarev@wirenboard.com>  Thu, 26 Jan 2022 12:00:00 +0400
+
 wb-zigbee2mqtt (1.1.0) stable; urgency=medium
 
   * add zigbee2mqtt 1.22+ support (should not break 1.18.1)

--- a/wb-zigbee2mqtt.js
+++ b/wb-zigbee2mqtt.js
@@ -67,10 +67,23 @@ defineRule("Permit join", {
             }, 5000);
         }
     });
+
+    //for zigbee2mqtt 1.18.x
     trackMqtt(base_topic + "/bridge/log", function(obj) {
         dev["zigbee2mqtt"]["Log"] = obj.value;
     });
 
+    //for zigbee2mqtt 1.21.x and above
+    trackMqtt(base_topic + "/bridge/logging", function(obj) {
+        var msg = JSON.parse(obj.value)
+
+        if (msg["message"].indexOf("MQTT publish") != 0){
+          dev["zigbee2mqtt"]["Log"] = msg["message"];
+          dev["zigbee2mqtt"]["Log level"] = msg["level"];
+        }
+    });
+
+    //for zigbee2mqtt 1.18.x
     trackMqtt(base_topic + "/bridge/config", function(obj) {
         if (obj.value != '') {
             JSON.parse(obj.value, function(k, v) {
@@ -84,6 +97,11 @@ defineRule("Permit join", {
         }
     });
 
+    //for zigbee2mqtt 1.21.x and above
+    trackMqtt(base_topic + "/bridge/info", function(obj) {
+        var msg = JSON.parse(obj.value)
+        dev["zigbee2mqtt"]["Version"] = msg["version"];
+    });
 
     trackMqtt(base_topic + "/bridge/response/permit_join", function(obj) {
         if (obj.value != '') {
@@ -94,7 +112,6 @@ defineRule("Permit join", {
             });
         }
     });
-
 
     trackMqtt(base_topic + "/bridge/devices", function(obj) {
         if (obj.value != '') {


### PR DESCRIPTION
В zigbee2mqtt версий 1.21 и новее лог ведётся в другом топике, поэтому пользователь оставался без обратной связи при подключении устройств или ошибках.

Техподдержка предлагала ставить в конфиге легаси параметры и тогда всё как бы работало, но это лишние телодвижения при чистой установке и неизвестно, сколько эти легаси параметры ещё проживут в продукте.

Добавил обработку нового топика лога и отфильтровал сообщения MQTT publish, которые для пользователя не имеют смысла. Заодно починил вывод версии. Обработку старых топиков оставил для совместимости с советами техподдержи про легаси параметры и старыми версиями.

Теперь у нас всё выглядит так:
![ksnip_20230126-113924](https://user-images.githubusercontent.com/77433258/214783521-e0710707-621e-4a54-ba47-c4ad50c811f1.png)
![ksnip_20230126-113936](https://user-images.githubusercontent.com/77433258/214783655-be8e584a-f6a9-4e37-a9fd-98a9e88c4094.png)
![ksnip_20230126-113951](https://user-images.githubusercontent.com/77433258/214783672-1934a1f9-47ec-4aa4-91ca-799649c89b1b.png)
![ksnip_20230126-114000](https://user-images.githubusercontent.com/77433258/214783755-bc920e83-66bc-453a-b554-9a0b51343a9e.png)
![ksnip_20230126-114053](https://user-images.githubusercontent.com/77433258/214783780-1733bf24-23a6-48c4-aec1-d5350e8caf8a.png)
