### PR TITLE
Add homepage to deb package info

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Wiren Board
+Copyright (c) 2020-2023 Wiren Board
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,8 @@
-DESTDIR=/
+PREFIX = /usr
 dummy:
 	echo
 
-
 install:
-	mkdir -p $(DESTDIR)/usr/share/wb-rules-system/rules
-	install -D -m 0644  wb-zigbee2mqtt.js $(DESTDIR)/usr/share/wb-rules-system/rules/wb-zigbee2mqtt.js
+	install -Dm0644 wb-zigbee2mqtt.js -t $(DESTDIR)$(PREFIX)/share/wb-rules-system/rules/
 	
 .PHONY: dummy install

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-zigbee2mqtt (1.3.2) stable; urgency=medium
+
+  * Add homepage to deb package info. No functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 25 Jul 2023 16:34:00 +0400
+
 wb-zigbee2mqtt (1.3.1) stable; urgency=medium
 
   * Format source code. No functional changes

--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Section: misc
 Priority: optional
 Standards-Version: 1.0.0
 Build-Depends: debhelper (>= 9), pkg-config
+Homepage: https://github.com/wirenboard/wb-zigbee2mqtt
 
 Package: wb-zigbee2mqtt
 Architecture: all


### PR DESCRIPTION
`wbci-changelog` uses `Homepage` from `deb/control`.