### PR TITLE
Add permit join support for z2m v2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-zigbee2mqtt (1.4.0) stable; urgency=medium
+
+  * Add support permit_join in zigbee2mqtt 2.0+
+
+ -- Mikhail Burchu <mikhail.burchu@wirenboard.com>  Wed, 12 Feb 2025 11:00:00 +0300
+
 wb-zigbee2mqtt (1.3.5) stable; urgency=medium
 
   * Translate titles

--- a/debian/control
+++ b/debian/control
@@ -1,5 +1,5 @@
 Source: wb-zigbee2mqtt
-Maintainer: Ian Ianin <ianin@wirenboard.ru>
+Maintainer: Wiren Board team <info@wirenboard.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.4

--- a/wb-zigbee2mqtt.js
+++ b/wb-zigbee2mqtt.js
@@ -15,6 +15,10 @@ var controlsTypes = {
   voltage: 'voltage',
 };
 
+var majorVersion = 0;
+var permit_join_info = false;
+var publish_lock = false;
+
 defineVirtualDevice('zigbee2mqtt', {
   title: { en: 'Zigbee2mqtt converter', ru: 'Zigbee2mqtt конвертер' },
   cells: {
@@ -60,7 +64,29 @@ defineRule('Update devices', {
 defineRule('Permit join', {
   whenChanged: 'zigbee2mqtt/Permit join',
   then: function (newValue, devName, cellName) {
-    publish(base_topic + '/bridge/request/permit_join', newValue);
+    var version = dev['zigbee2mqtt']['Version'] || '';
+    var versionParts = version.split('.').map(Number);
+    majorVersion = versionParts.length > 0 ? versionParts[0] : 0;
+
+    //for zigbee2mqtt 1.42.x and below
+    if (majorVersion < 2) {
+      publish(base_topic + '/bridge/request/permit_join', newValue);
+    }
+
+    //for zigbee2mqtt 2.x.x and above
+    else {
+      var payload;
+      payload = newValue ? JSON.stringify({ time: 15 }) : JSON.stringify({ time: 0 });
+      //log.info("Состояние newValue: {}".format(newValue));
+      //log.info("Состояние publish_lock: {}".format(publish_lock));
+      if (!publish_lock) {
+        if ((!permit_join_info && newValue)|(permit_join_info && !newValue)) {
+          //log.info("Состояние publish: {}".format(true));
+          publish(base_topic + '/bridge/request/permit_join', payload);
+        }
+      }
+    }
+
   },
 });
 
@@ -107,6 +133,16 @@ defineRule('Permit join', {
   trackMqtt(base_topic + '/bridge/info', function (obj) {
     var msg = JSON.parse(obj.value);
     dev['zigbee2mqtt']['Version'] = msg['version'];
+
+    //for zigbee2mqtt 2.x.x and above
+    if (majorVersion >= 2) {
+      permit_join_info = msg['permit_join'];
+      if (!msg['permit_join'] && dev['zigbee2mqtt']['Permit join']) {
+        dev['zigbee2mqtt']['Permit join'] = false;
+        publish_lock = false;
+      }
+    }
+
   });
 
   trackMqtt(base_topic + '/bridge/response/permit_join', function (obj) {
@@ -115,6 +151,19 @@ defineRule('Permit join', {
         if (k == 'value') {
           dev['zigbee2mqtt']['Permit join'] = v;
         }
+
+        //for zigbee2mqtt 2.x.x and above
+        else if (k == 'time' && majorVersion >= 2) {
+          if (v == 0 && dev['zigbee2mqtt']['Permit join']) {
+            publish_lock = true;
+            dev['zigbee2mqtt']['Permit join'] = false;
+          }
+          else if (v != 0 && !dev['zigbee2mqtt']['Permit join']) {
+            publish_lock = true;
+            dev['zigbee2mqtt']['Permit join'] = true;
+          }
+        }
+
       });
     }
   });

--- a/wb-zigbee2mqtt.js
+++ b/wb-zigbee2mqtt.js
@@ -76,7 +76,7 @@ defineRule('Permit join', {
     //for zigbee2mqtt 2.x.x and above
     else {
       var payload;
-      payload = newValue ? JSON.stringify({ time: 15 }) : JSON.stringify({ time: 0 });
+      payload = newValue ? JSON.stringify({ time: 254 }) : JSON.stringify({ time: 0 });
       //log.info("Состояние newValue: {}".format(newValue));
       //log.info("Состояние publish_lock: {}".format(publish_lock));
       if (!publish_lock) {


### PR DESCRIPTION
В версии z2m 2.0 включение спаривания устройств теперь происходит отправкой сообщения типа {"time":254} или {"time":0}. В предыдущих версиях это было через {"value":true} - в новой версии это не работает. Проверил на версиях z2m 1.18.1 и 1.42.0, что для версии ниже 2.0 осталось старое поведение, а для новой версии корректно включается режим спаривания.