### PR TITLE
Add function initTrackerAvailability for zigbee device status (online…

### DIFF
--- a/wb-zigbee2mqtt.js
+++ b/wb-zigbee2mqtt.js
@@ -179,6 +179,7 @@ defineRule('Permit join', {
               cells: {},
             });
             initTracker(v);
+            initTrackerAvailability(v);
           }
         }
       });
@@ -201,6 +202,31 @@ function getControlValue(contolName, controlValue, controlsTypes) {
     return JSON.stringify(controlValue);
   }
   return controlValue.toString();
+}
+
+function initTrackerAvailability(deviceName) {
+  trackMqtt(base_topic + '/' + deviceName + '/availability', function (obj) {
+    var name = getFriendlyName(deviceName);
+    var device = JSON.parse(obj.value);
+    for (var controlName in device) {
+      if (controlName == '') {
+        continue;
+      }
+      if (!getDevice(name).isControlExists(controlName)) {
+        getDevice(name).addControl(controlName, {
+          type: getControlType(controlName, controlsTypes),
+          value: getControlValue(controlName, device[controlName], controlsTypes),
+          readonly: true,
+        });
+      } else {
+        dev[name][controlName] = getControlValue(
+          controlName,
+          device[controlName],
+          controlsTypes
+        );
+      }
+    }
+  });
 }
 
 function initTracker(deviceName) {


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Добавление функции, которая добавляет control в zigbee устройство с его статусом. Эта функция конвертирует данные из канала MQTT zigbee2mqtt в канал WB. 

Например, вы настроили устройство со следующим параметром `availability` (в файле /mnt/data/root/zigbee2mqtt/data/configuration.yaml): 

```
devices:
  '0x0xxxxxxxxxxxxxxxxxx':
    friendly_name: sample_device_id_1
    description: Sample device
    availability:
      timeout: 300
```

После данного улучшения в MQTT WB появится канал `/devices/sample_device_id_1/controls/state` со статусом устройства (будет показывать `offline` или `online`). `offline` будет показывать если устройство не отправляло никаких данных в течении времени указанного в параметре `availability` (в нашем случае из примера выше - 300 минут). 

Ссылка на документацию zigbee2mqtt - https://www.zigbee2mqtt.io/guide/configuration/device-availability.html 

Это нужно для того чтобы делать правила и алерты на основе статуса zigbee устройства, если устройство давно не доступно (например отвалилось или зависло), например для датчиков обнаружения протечки (что критически важно).  


___________________________________
**Что поменялось для пользователей:**

Появится новый канал со статусом zigbee устройства. 

___________________________________
**Как проверял/а:**

Для проверки: 
- применить изменения
- настроить zigbee устройство в файле `/mnt/data/root/zigbee2mqtt/data/configuration.yaml` (задать availability timeout)
- перезапустить wb-rules и zigbee2mqtt
- должен появится еще один канал со статусом устройства 



