### PR TITLE
Fix for receiving null value

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-zigbee2mqtt (1.4.2) stable; urgency=medium
+
+  * Fix for receiving null value in 2.x version
+
+ -- Ilya Titov <ilya.tikhonyuk@wirenboard.com>  Tue, 10 Mar 2026 13:20:00 +0300
+
 wb-zigbee2mqtt (1.4.1) stable; urgency=medium
 
   * Fix parsing device friendly_name for values with slashes 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ wb-zigbee2mqtt (1.4.2) stable; urgency=medium
 
   * Fix for receiving null value
 
- -- Ilya Titov <ilya.tikhonyuk@wirenboard.com>  Tue, 10 Mar 2026 13:20:00 +0300
+ -- Ilya Tikhonyuk <ilya.tikhonyuk@wirenboard.com>  Tue, 10 Mar 2026 13:20:00 +0300
 
 wb-zigbee2mqtt (1.4.1) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-zigbee2mqtt (1.4.2) stable; urgency=medium
 
-  * Fix for receiving null value in 2.x version
+  * Fix for receiving null value
 
  -- Ilya Titov <ilya.tikhonyuk@wirenboard.com>  Tue, 10 Mar 2026 13:20:00 +0300
 

--- a/wb-zigbee2mqtt.js
+++ b/wb-zigbee2mqtt.js
@@ -133,6 +133,8 @@ defineRule('Permit join', {
   trackMqtt(base_topic + '/bridge/info', function (obj) {
     var msg = JSON.parse(obj.value);
     dev['zigbee2mqtt']['Version'] = msg['version'];
+    var versionParts = msg['version'].split('.').map(Number);
+    majorVersion = versionParts.length > 0 ? versionParts[0] : 0;
 
     //for zigbee2mqtt 2.x.x and above
     if (majorVersion >= 2) {
@@ -195,7 +197,8 @@ function getControlType(controlName, controlsTypes) {
 }
 
 function getControlValue(contolName, controlValue, controlsTypes) {
-  if (controlValue === null || controlValue === undefined) return undefined;
+  //for zigbee2mqtt 2.x.x and above: skip null/undefined to avoid TypeError
+  if (majorVersion >= 2 && (controlValue === null || controlValue === undefined)) return undefined;
   if (contolName in controlsTypes) return controlValue;
   if (controlValue == null) return '';
   if (typeof controlValue === 'object') {

--- a/wb-zigbee2mqtt.js
+++ b/wb-zigbee2mqtt.js
@@ -195,6 +195,7 @@ function getControlType(controlName, controlsTypes) {
 }
 
 function getControlValue(contolName, controlValue, controlsTypes) {
+  if (controlValue === null || controlValue === undefined) return undefined;
   if (contolName in controlsTypes) return controlValue;
   if (controlValue == null) return '';
   if (typeof controlValue === 'object') {
@@ -211,6 +212,12 @@ function initTracker(deviceName) {
       if (controlName == '') {
         continue;
       }
+
+      var value = getControlValue(controlName, device[controlName], controlsTypes);
+      if (value === undefined) {
+        continue;
+      }
+
       if (!getDevice(name).isControlExists(controlName)) {
         getDevice(name).addControl(controlName, {
           type: getControlType(controlName, controlsTypes),

--- a/wb-zigbee2mqtt.js
+++ b/wb-zigbee2mqtt.js
@@ -133,8 +133,6 @@ defineRule('Permit join', {
   trackMqtt(base_topic + '/bridge/info', function (obj) {
     var msg = JSON.parse(obj.value);
     dev['zigbee2mqtt']['Version'] = msg['version'];
-    var versionParts = msg['version'].split('.').map(Number);
-    majorVersion = versionParts.length > 0 ? versionParts[0] : 0;
 
     //for zigbee2mqtt 2.x.x and above
     if (majorVersion >= 2) {
@@ -197,8 +195,7 @@ function getControlType(controlName, controlsTypes) {
 }
 
 function getControlValue(contolName, controlValue, controlsTypes) {
-  //for zigbee2mqtt 2.x.x and above: skip null/undefined to avoid TypeError
-  if (majorVersion >= 2 && (controlValue === null || controlValue === undefined)) return undefined;
+  if (controlValue === null || controlValue === undefined) return undefined;
   if (contolName in controlsTypes) return controlValue;
   if (controlValue == null) return '';
   if (typeof controlValue === 'object') {


### PR DESCRIPTION
Задача в ютрак: [INT-828](https://wirenboard.youtrack.cloud/issue/INT-828/Oshibka-konvertera-wb-zigbee2mqtt-pri-nalichii-znacheniya-null-u-polya-poluchaemyh-dannyh-zigbee-ustrojstva)

Исправил баг при получении значние null.

Добавил проверку: теперь при получении null или undefaunded значения параметра не отправляется
Протестировал на версиях:
zigbee2mqtt-2.1.1
zigbee2mqtt-1.18.1
и актуально 2.8.0
Тестировал на стенде ручной проверки зигби: [ссылка](https://github.com/wirenboard/integration-test-benches/tree/main/projects/zigbee-manual-testing).